### PR TITLE
Add code to prep predictors folder

### DIFF
--- a/tutorial/5_Predictors.md
+++ b/tutorial/5_Predictors.md
@@ -20,6 +20,14 @@ That is, if you have your data in the [json lines format](http://jsonlines.org/)
 However, in our case our data isn't in JSON lines format, it's in the CoNLL format.
 Thankfully, AllenNLP has a flag called `--use-dataset-reader` which will allow us to get around this, as you'll see!
 
+We will now create a `predictors` folder to store any predictors we create and populate it with the files we'll need:
+
+```
+mkdir tagging/predictors
+touch tagging/predictors/__init__.py
+touch tagging/predictors/conll_predictor.py
+```
+
 ## 5.2 Building a Basic Predictor
 
 As with `Model`s and `DatasetReader`s, we're going to start by inheriting from a base AllenNLP class and registering it so we can use it in the config file.


### PR DESCRIPTION
First, thanks for the excellent tutorial!

Following along with tutorial 5, so far the guide assumes the predictors folder and relevant files are already created (in the same way that they were for building the dataset readers and models).

This small fix just adds the code necessary to prep the `predictors`  folder.