### PR TITLE
fix forward pass to match self._f1 declared in init

### DIFF
--- a/tagging/models/lstm_crf.py
+++ b/tagging/models/lstm_crf.py
@@ -61,7 +61,7 @@ class NerLstmCRF(Model):
         broadcasted = self._broadcast_tags(viterbi_tags, classified)
 
         log_likelihood = self._crf(classified, label, mask)
-        self._accuracy(broadcasted, label, mask)
+        self._f1(broadcasted, label, mask)
 
         output: Dict[str, torch.Tensor] = {}
         output["loss"] = -log_likelihood

--- a/tutorial/7_Advanced_Modeling.md
+++ b/tutorial/7_Advanced_Modeling.md
@@ -156,7 +156,7 @@ class NerLstmCRF(Model):
         broadcasted = self._broadcast_tags(viterbi_tags, classified)
 
         log_likelihood = self._crf(classified, label, mask)
-        self._accuracy(broadcasted, label, mask)
+        self._f1(broadcasted, label, mask)
 
         output: Dict[str, torch.Tensor] = {}
         output["loss"] = -log_likelihood


### PR DESCRIPTION
Mostly I just want to say thank you so much for making this tutorial guide! It's been a tremendous help to me as I'm trying to get my feet wet with allennlp for the first time. 🤗 

I was playing around trying to run the CRF decoding code in this section (with the specified config file) and ran into an error about self._accuracy not being defined. I'm pretty sure that this fixes it and matches the intention of the model. (Seems to be working well for me now at least.)