### PR TITLE
Update advanced models to AllenNLP 1+

### DIFF
--- a/configs/train_hierarchical_lstm.jsonnet
+++ b/configs/train_hierarchical_lstm.jsonnet
@@ -13,28 +13,33 @@
       }
     }
   },
-  iterator: {
-    type: 'bucket',
-    sorting_keys: [['tokens', 'num_tokens']],
-    batch_size: 10
+  data_loader: {
+    batch_sampler: {
+      type: 'bucket',
+      batch_size: 10
+    }
   },
   train_data_path: 'data/train.txt',
   validation_data_path: 'data/validation.txt',
   model: {
     type: 'hierarchical_lstm',
     word_embedder: {
-      tokens: {
-        type: 'embedding',
-        pretrained_file: "(http://nlp.stanford.edu/data/glove.6B.zip)#glove.6B.50d.txt",
-        embedding_dim: 50,
-        trainable: false
+      token_embedders: {
+        tokens: {
+          type: 'embedding',
+          pretrained_file: "(http://nlp.stanford.edu/data/glove.6B.zip)#glove.6B.50d.txt",
+          embedding_dim: 50,
+          trainable: false
+        }
       }
     },
     character_embedder: {
-      characters: {
-        type: 'embedding',
-        embedding_dim: 10,
-        trainable: true
+      token_embedders: {
+        characters: {
+          type: 'embedding',
+          embedding_dim: 10,
+          trainable: true
+        }
       }
     },
     character_encoder: {

--- a/configs/train_lstm_crf.jsonnet
+++ b/configs/train_lstm_crf.jsonnet
@@ -10,21 +10,24 @@
     },
     lazy: false
   },
-  iterator: {
-    type: 'bucket',
-    sorting_keys: [['tokens', 'num_tokens']],
-    batch_size: 10
+  data_loader: {
+    batch_sampler: {
+      type: 'bucket',
+      batch_size: 10
+    }
   },
   train_data_path: 'data/train.txt',
   validation_data_path: 'data/validation.txt',
   model: {
     type: 'ner_lstm_crf',
     embedder: {
-      tokens: {
-        type: 'embedding',
-        pretrained_file: "(http://nlp.stanford.edu/data/glove.6B.zip)#glove.6B.50d.txt",
-        embedding_dim: 50,
-        trainable: false
+      token_embedders: {
+        tokens: {
+          type: 'embedding',
+          pretrained_file: "(http://nlp.stanford.edu/data/glove.6B.zip)#glove.6B.50d.txt",
+          embedding_dim: 50,
+          trainable: false
+        }
       }
     },
     encoder: {

--- a/tagging/models/lstm_character.py
+++ b/tagging/models/lstm_character.py
@@ -8,7 +8,7 @@ from allennlp.modules.text_field_embedders import TextFieldEmbedder
 from allennlp.nn.util import get_text_field_mask, sequence_cross_entropy_with_logits
 from allennlp.modules.seq2seq_encoders.seq2seq_encoder import Seq2SeqEncoder
 from allennlp.modules.seq2vec_encoders.seq2vec_encoder import Seq2VecEncoder
-from allennlp.training.metrics import CategoricalAccuracy
+from allennlp.training.metrics import CategoricalAccuracy, SpanBasedF1Measure
 
 from typing import Optional, Dict, Any, List
 
@@ -69,6 +69,9 @@ class HierarchicalLstm(Model):
         encoded = self._encoder(embedded, mask)
 
         classified = self._classifier(encoded)
+
+        output: Dict[str, torch.Tensor] = {}
+        output['logits'] = classified
 
         if label is not None:
             self._f1(classified, label, mask)


### PR DESCRIPTION
I updated the config and model code for the advanced models.
I know these aren't currently discussed in the tutorial, but I found the code helpful.

What changed:
- configs: replaced `iterator` with `dataloader`, wrapped `embedders` with `token_embedders` dict as required by AllenNLP v1+.
- model code for `lstm_character.py`: init output dict and place logits in there for the predictor.

Tested and working with AllenNLP v1.1.0.