### PR TITLE
Fix train_lstm example for use with allennlp v2.9.3

### DIFF
--- a/configs/test_reader.jsonnet
+++ b/configs/test_reader.jsonnet
@@ -1,10 +1,11 @@
 {
   dataset_reader: {
-    type: 'conll_03_reader',
-    lazy: false
+    type: 'conll_03_reader'
   },
   model: {},
-  data_loader: {},
+  data_loader: {
+    batch_size: 10
+  },
   trainer: {},
   train_data_path: 'data/train.txt',
   validation_data_path: 'data/validation.txt'

--- a/configs/train_hierarchical_lstm.jsonnet
+++ b/configs/train_hierarchical_lstm.jsonnet
@@ -1,7 +1,6 @@
 {
   dataset_reader: {
     type: 'conll_03_reader',
-    lazy: false,
     token_indexers: {
       tokens: {
         type: 'single_id',

--- a/configs/train_lstm.jsonnet
+++ b/configs/train_lstm.jsonnet
@@ -8,7 +8,6 @@
         lowercase_tokens: true
       }
     },
-    lazy: false
   },
   data_loader: {
     batch_sampler: {

--- a/configs/train_lstm_crf.jsonnet
+++ b/configs/train_lstm_crf.jsonnet
@@ -8,7 +8,6 @@
         lowercase_tokens: true
       }
     },
-    lazy: false
   },
   data_loader: {
     batch_sampler: {

--- a/tagging/readers/conll_reader.py
+++ b/tagging/readers/conll_reader.py
@@ -16,8 +16,9 @@ def is_divider(line):
 class CoNLL03DatasetReader(DatasetReader):
     def __init__(self,
                  token_indexers: Dict[str, TokenIndexer] = None,
-                 lazy: bool = False) -> None:
-        super().__init__(lazy)
+                 **kwargs,
+                 ) -> None:
+        super().__init__(**kwargs)
         self._token_indexers = token_indexers or {'tokens': SingleIdTokenIndexer()}
 
     @overrides
@@ -41,8 +42,9 @@ class CoNLL03DatasetReader(DatasetReader):
 
     @overrides
     def text_to_instance(self,
-                         words: List[str],
-                         ner_tags: List[str]) -> Instance:
+                         *inputs) -> Instance:
+        (words, ner_tags) = inputs
+
         fields: Dict[str, Field] = {}
         # wrap each token in the file with a token object
         tokens = TextField([Token(w) for w in words], self._token_indexers)

--- a/tutorial/3_Configuring_Experiments.md
+++ b/tutorial/3_Configuring_Experiments.md
@@ -116,7 +116,6 @@ To see where we get the `tokens` namespace from, imagine that we instead told ou
 ```
   dataset_reader: {
     type: 'conll_03_reader',
-    lazy: false,
     token_indexers: {
       words: {
         type: 'single_id'


### PR DESCRIPTION
This fixes various errors when attempting to run against allennlp v2.9.3

Currently fixed the train_lstm example.